### PR TITLE
Don't overwrite CFLAGS and LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC=gcc
 //CFLAGS = -g -Wall -O3 -std=gnu99 -DCHANNELS=2
-CFLAGS = -g -Wall -O3 -std=gnu99 -DCHANNELS=2
+CFLAGS += -g -Wall -O3 -std=gnu99 -DCHANNELS=2
 # -DZEROMQ="\"tcp://178.77.72.138:5556\""
-LDFLAGS = -lm -llo -lsndfile -lsamplerate -ljack
+LDFLAGS += -lm -llo -lsndfile -lsamplerate -ljack
 # -lzmq
 #  -lxtract
 


### PR DESCRIPTION
Appending to CFLAGS and LDFLAGS allows easy configuration if libs aren't installed to standard locations.

I use boxen to configure my mac, which means that homebrew installed libs are under /opt/boxen/homebrew/include. Currently the makefile overwrites my environment variables so I can't compile Dirt. This fixes it so I can just set CFLAGS and LDFLAGS and compile Dirt fine
