### PR TITLE
Add -dc command-line argument for disabling dirty compressor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 
 
-CFLAGS += -g -I/usr/local/include -Wall -O3 -std=gnu99 -DCHANNELS=2 -DDIRTYCOMPRESSOR
+CFLAGS += -g -I/usr/local/include -Wall -O3 -std=gnu99 -DCHANNELS=2
 LDFLAGS += -lm -L/usr/local/lib -llo -lsndfile -lsamplerate -ljack
 
 all: dirt

--- a/audio.c
+++ b/audio.c
@@ -36,6 +36,9 @@ float compression_speed = -1;
 float delay_time = 0.1;
 float delay_feedback = 0.7;
 
+bool use_dirty_compressor = false;
+
+
 int queue_size(t_sound *queue) {
   int result = 0;
   while (queue != NULL) {
@@ -665,23 +668,23 @@ void playback(float **buffers, int frame, jack_nframes_t frametime) {
     buffers[channel][frame] += tmp;
   }
 
-#ifdef DIRTYCOMPRESSOR
-  float max = 0;
-    
-  for (channel = 0; channel < CHANNELS; ++channel) {
-    if (fabsf(buffers[channel][frame]) > max) {
-      max = buffers[channel][frame];
+  if (use_dirty_compressor) {
+    float max = 0;
+
+    for (channel = 0; channel < CHANNELS; ++channel) {
+      if (fabsf(buffers[channel][frame]) > max) {
+        max = buffers[channel][frame];
+      }
+    }
+    float factor = compress(max);
+    for (channel = 0; channel < CHANNELS; ++channel) {
+      buffers[channel][frame] *= factor * 0.4;
+    }
+  } else {
+    for (channel = 0; channel < CHANNELS; ++channel) {
+      buffers[channel][frame] *= 0.4;
     }
   }
-  float factor = compress(max);
-  for (channel = 0; channel < CHANNELS; ++channel) {
-    buffers[channel][frame] *= factor * 0.4;
-  }
-#else
-  for (channel = 0; channel < CHANNELS; ++channel) {
-    buffers[channel][frame] *= 0.4;
-  }
-#endif
 }
 
 #ifdef FEEDBACK
@@ -776,7 +779,7 @@ void audio_pause_input(int paused) {
 
 #endif
 
-extern void audio_init(void) {
+extern void audio_init(bool dirty_compressor) {
   struct timeval tv;
   gettimeofday(&tv, NULL);
   starttime = (float) tv.tv_sec + ((float) tv.tv_usec / 1000000.0);
@@ -794,4 +797,6 @@ extern void audio_init(void) {
 #ifdef FEEDBACK
   pitch_init(loop, samplerate);
 #endif
+
+  use_dirty_compressor = dirty_compressor;
 }

--- a/audio.h
+++ b/audio.h
@@ -2,6 +2,7 @@
 #include "file.h"
 #include "jack.h"
 #include "config.h"
+#include "common.h"
 
 #define MAXLINE  44100
 #define MAXSOUNDS 1024
@@ -78,7 +79,7 @@ typedef struct t_node {
 
 
 extern int audio_callback(int frames, float *input, float **outputs);
-extern void audio_init(void);
+extern void audio_init(bool dirty_compressor);
 extern int audio_play(double when, char *samplename, float offset, float start, float end, float speed, float pan, float velocity, int vowelnum, float cutoff, float resonance, float accelerate, float shape, int kriole_chunk, float gain, int cutgroup, float delay, float delaytime, float delayfeedback);
 
 extern void audio_kriole(double when, 

--- a/common.h
+++ b/common.h
@@ -1,0 +1,7 @@
+#ifndef __COMMON_H__
+#define __COMMON_H__
+
+#include <stdbool.h>
+#define bool _Bool
+
+#endif // __COMMON_H__

--- a/dirt.c
+++ b/dirt.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <string.h>
 
+#include "common.h"
 #include "jack.h"
 #include "audio.h"
 #include "server.h"
@@ -18,8 +19,14 @@ int main (int argc, char **argv) {
       return(0);
   }
 
+  bool dirty_compressor = true;
+  if (argc > 1 && strncmp(argv[1], "-dc", 3) >= 0) {
+      dirty_compressor = false;
+      fprintf(stderr, "dirty compressor disabled\n");
+  }
+
   fprintf(stderr, "init audio\n");
-  audio_init();
+  audio_init(dirty_compressor);
 
   fprintf(stderr, "init open sound control\n");
   server_init();


### PR DESCRIPTION
Add a -dc option for running dirt without the dirty compressor. The compressor is enabled by default for now, at least until we came up with a better solution to sampling volume (normalizing samples maybe?).
