### PR TITLE
getopt, add --no-dirty-compressor and --no-jack-auto-connect command line arguments

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <dirent.h>
 
+#include "common.h"
 #include "config.h"
 
 #ifdef JACK
@@ -828,8 +829,8 @@ void audio_pause_input(int paused) {
 #endif
 
 #ifdef JACK
-void jack_init(void) {
-  jack_client = jack_start(jack_callback);
+void jack_init(bool autoconnect) {
+  jack_client = jack_start(jack_callback, autoconnect);
   samplerate = jack_get_sample_rate(jack_client);
 }
 #else
@@ -916,7 +917,7 @@ error:
 }
 #endif
 
-extern void audio_init(bool dirty_compressor) {
+extern void audio_init(bool dirty_compressor, bool autoconnect) {
   struct timeval tv;
   gettimeofday(&tv, NULL);
   starttime = (float) tv.tv_sec + ((float) tv.tv_usec / 1000000.0);
@@ -926,7 +927,7 @@ extern void audio_init(bool dirty_compressor) {
 
   pthread_mutex_init(&queue_waiting_lock, NULL);
 #ifdef JACK
-  jack_init();
+  jack_init(autoconnect);
 #else
   pa_init();
 #endif

--- a/audio.h
+++ b/audio.h
@@ -86,7 +86,7 @@ typedef struct t_node {
 
 
 extern int audio_callback(int frames, float *input, float **outputs);
-extern void audio_init(bool dirty_compressor);
+extern void audio_init(bool dirty_compressor, bool autoconnect);
 extern int audio_play(double when, char *samplename, float offset, float start, float end, float speed, float pan, float velocity, int vowelnum, float cutoff, float resonance, float accelerate, float shape, int kriole_chunk, float gain, int cutgroup, float delay, float delaytime, float delayfeedback);
 
 extern void audio_kriole(double when, 

--- a/dirt.c
+++ b/dirt.c
@@ -8,6 +8,9 @@
 #include "server.h"
 
 static int dirty_compressor_flag = 1;
+#ifdef JACK
+static int jack_auto_connect_flag = 1;
+#endif
 
 int main (int argc, char **argv) {
   /* Use getopt to parse command-line arguments */
@@ -23,6 +26,10 @@ int main (int argc, char **argv) {
 
       {"dirty-compressor",      no_argument, &dirty_compressor_flag, 1},
       {"no-dirty-compressor",   no_argument, &dirty_compressor_flag, 0},
+#ifdef JACK
+      {"jack-auto-connect",     no_argument, &jack_auto_connect_flag, 1},
+      {"no-jack-auto-connect",  no_argument, &jack_auto_connect_flag, 0},
+#endif
 
       {"version", no_argument, 0, 'v'},
       {"help",    no_argument, 0, 'h'},
@@ -61,6 +68,10 @@ int main (int argc, char **argv) {
                "Arguments:\n"
                "      --dirty-compressor          enable dirty compressor on audio output (default)\n"
                "      --no-dirty-compressor       disable dirty compressor on audio output\n"
+#ifdef JACK
+               "      --jack-auto-connect         automatically connect to writable clients (default)\n"
+               "      --no-jack-auto-connect      do not connect to writable clients  \n"
+#endif
                "  -h, --help                      display this help and exit\n"
                "  -v, --version                   output version information and exit\n",
                OSC_PORT);
@@ -79,8 +90,18 @@ int main (int argc, char **argv) {
     fprintf(stderr, "dirty compressor disabled\n");
   }
 
+#ifdef JACK
+  if (!jack_auto_connect_flag) {
+    fprintf(stderr, "port auto-connection disabled\n");
+  }
+#endif
+
   fprintf(stderr, "init audio\n");
-  audio_init(dirty_compressor_flag);
+#ifdef JACK
+  audio_init(dirty_compressor_flag, jack_auto_connect_flag);
+#else
+  audio_init(dirty_compressor_flag, true);
+#endif
 
   fprintf(stderr, "init open sound control\n");
   server_init();

--- a/jack.c
+++ b/jack.c
@@ -44,8 +44,7 @@ void jack_shutdown(void *arg) {
   exit(1);
 }
 
-extern jack_client_t *jack_start(t_callback callback) {
-  const char **ports;
+extern jack_client_t *jack_start(t_callback callback, bool autoconnect) {
   const char *client_name = "dirt";
   const char *server_name = NULL;
   jack_options_t options = JackNullOption;
@@ -110,27 +109,30 @@ extern jack_client_t *jack_start(t_callback callback) {
     exit(1);
   }
 
-  ports = jack_get_ports(client, NULL, NULL,
-                         JackPortIsPhysical|JackPortIsInput);
-  for (i = 0; i < CHANNELS; ++i) {
-    if (ports[i] == NULL) {
-      break;
+  if (autoconnect) {
+    const char **ports;
+    ports = jack_get_ports(client, NULL, NULL,
+                           JackPortIsPhysical|JackPortIsInput);
+    for (i = 0; i < CHANNELS; ++i) {
+      if (ports[i] == NULL) {
+        break;
+      }
+      //sprintf(portname, "output_%d", i);
+      if (jack_connect(client, jack_port_name(output_ports[i]), ports[i])) {
+        fprintf(stderr, "cannot connect output ports\n");
+      }
     }
-    //sprintf(portname, "output_%d", i);
-    if (jack_connect(client, jack_port_name(output_ports[i]), ports[i])) {
-      fprintf(stderr, "cannot connect output ports\n");
-    }
-  }
 
 #ifdef INPUT
-  ports = jack_get_ports(client, NULL, NULL,
-                         JackPortIsPhysical|JackPortIsOutput);
-  //strcpy(portname, "input");
-  if (jack_connect(client, ports[0], jack_port_name(input_port))) {
-    fprintf(stderr, "cannot connect input port\n");
-  }
+    ports = jack_get_ports(client, NULL, NULL,
+                           JackPortIsPhysical|JackPortIsOutput);
+    //strcpy(portname, "input");
+    if (jack_connect(client, ports[0], jack_port_name(input_port))) {
+      fprintf(stderr, "cannot connect input port\n");
+    }
 #endif
-  free(ports);
+    free(ports);
+  }
 
   return(client);
 }

--- a/jack.h
+++ b/jack.h
@@ -1,6 +1,7 @@
 #ifndef _DIRTJACKH_
 #define _DIRTJACKH_
 #include <jack/jack.h>
+#include "common.h"
 
 #ifndef CHANNELS
 #define CHANNELS 2
@@ -8,5 +9,5 @@
 
 typedef int (*t_callback)(int, float *, float **);
 
-extern jack_client_t *jack_start(t_callback callback);
+extern jack_client_t *jack_start(t_callback callback, bool autoconnect);
 #endif


### PR DESCRIPTION
This changes the `-dc` argument for `--no-dirty-compressor` and adds an additional argument `--no-jack-auto-connect` to disable JACK port autoconnection, to make it easier to use another compressor or more complex audio workflows with JACK.

Auto-connection is enabled by default, so running `./dirt` gets the normal behavior as always. I think it's good to auto-connect by default (regardless of the opinion of JACK users/developers), but better to have an option to disable for more advanced users.

I used _getopt.h_ for command-line argument parsing, which is what most C GNU software use, based on [this example](http://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html#Getopt-Long-Option-Example). This makes it easier to add new options in the future.
