### PR TITLE
Load samples asynchronously in a separate thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS += -g -I/usr/local/include -Wall -O3 -std=gnu99
 LDFLAGS += -lm -L/usr/local/lib -llo -lsndfile -lsamplerate
 
 dirt: CFLAGS += -DJACK -DSCALEPAN
-dirt: LDFLAGS += -ljack
+dirt: LDFLAGS += -ljack -lpthread
 dirt-pa: LDFLAGS += -lportaudio
 
 all: dirt

--- a/file.c
+++ b/file.c
@@ -3,7 +3,9 @@
 #include <string.h>
 #include <dirent.h>
 #include <stdlib.h>
+#include <pthread.h>
 
+#include "common.h"
 #include "file.h"
 #include "segment.h"
 
@@ -11,6 +13,14 @@ t_sample *samples[MAXSAMPLES];
 int sample_count = 0;
 
 int samplerate = 44100;
+
+bool loading_file = false;
+bool mutex_init = false;
+
+pthread_t file_thread;
+pthread_mutex_t mutex_loading_file;
+pthread_mutex_t mutex_samples;
+
 
 extern void file_set_samplerate(int s) {
   samplerate = s;
@@ -39,13 +49,18 @@ void free_loop(t_loop *loop) {
 t_sample *find_sample (char *samplename) {
   int c;
   t_sample *sample = NULL;
-  
+
+  pthread_mutex_lock(&mutex_samples);
+
   for(c = 0; c < sample_count; ++c) {
     if(strcmp(samples[c]->name, samplename) == 0) {
       sample = samples[c];
       break;
     }
   }
+
+  pthread_mutex_unlock(&mutex_samples);
+
   return(sample);
 }
 
@@ -89,11 +104,11 @@ void fix_samplerate (t_sample *sample) {
   //printf("end samplerate: %d frames: %d\n", (int) sample->info->samplerate, sample->info->frames);  
 }
 
-extern t_sample *file_get(char *samplename) {
+void* file_read_thr(void *args) {
+  t_sample *sample = NULL;
   SNDFILE *sndfile;
   char path[MAXPATHSIZE];
   char error[62];
-  t_sample *sample;
   sf_count_t count;
   float *items;
   SF_INFO *info;
@@ -102,67 +117,111 @@ extern t_sample *file_get(char *samplename) {
   int set_n = 0;
   struct dirent **namelist;
 
-  sample = find_sample(samplename);
-  
-  if (sample == NULL) {
-    /* load it from disk */
-    if (sscanf(samplename, "%[a-z0-9A-Z]%[/:]%d", set, sep, &set_n)) {
-      int n;
-      snprintf(path, MAXPATHSIZE -1, "%s/%s", SAMPLEROOT, set);
-      //printf("looking in %s\n", set);
-      n = scandir(path, &namelist, wav_filter, alphasort);
-      if (n > 0) {
-        snprintf(path, MAXPATHSIZE -1, 
-                 "%s/%s/%s", SAMPLEROOT, set, namelist[set_n % n]->d_name);
-        while (n--) {
-          free(namelist[n]);
-        }
-        free(namelist);
+  char* samplename = args;
+
+  // load it from disk
+  if (sscanf(samplename, "%[a-z0-9A-Z]%[/:]%d", set, sep, &set_n)) {
+    int n;
+    snprintf(path, MAXPATHSIZE -1, "%s/%s", SAMPLEROOT, set);
+    //printf("looking in %s\n", set);
+    n = scandir(path, &namelist, wav_filter, alphasort);
+    if (n > 0) {
+      snprintf(path, MAXPATHSIZE -1,
+          "%s/%s/%s", SAMPLEROOT, set, namelist[set_n % n]->d_name);
+      while (n--) {
+        free(namelist[n]);
       }
-      else {
-	snprintf(path, MAXPATHSIZE -1, "%s/%s", SAMPLEROOT, samplename);
-      }
-    }
-    else {
+      free(namelist);
+    } else {
       snprintf(path, MAXPATHSIZE -1, "%s/%s", SAMPLEROOT, samplename);
     }
-    info = (SF_INFO *) calloc(1, sizeof(SF_INFO));
-    
-    printf("opening %s.\n", path);
-    if ((sndfile = (SNDFILE *) sf_open(path, SFM_READ, info)) == NULL) {
-      printf("nope.\n");
-      free(info);
-    }
-    else {
-      items = (float *) calloc(1, sizeof(float) * info->frames * info->channels);
-      /*snprintf(error, (size_t) 61, "hm: %d\n", sf_error(sndfile));
-      perror(error);*/
-      count  = sf_read_float(sndfile, items, info->frames * info->channels);
-      snprintf(error, (size_t) 61, "count: %d frames: %d channels: %d\n", (int) count, (int) info->frames, info->channels); 
+  } else {
+    snprintf(path, MAXPATHSIZE -1, "%s/%s", SAMPLEROOT, samplename);
+  }
+
+  info = (SF_INFO *) calloc(1, sizeof(SF_INFO));
+
+  printf("opening %s.\n", path);
+
+  if ((sndfile = (SNDFILE *) sf_open(path, SFM_READ, info)) == NULL) {
+    printf("nope.\n");
+    free(info);
+  } else {
+    items = (float *) calloc(1, sizeof(float) * info->frames * info->channels);
+    //snprintf(error, (size_t) 61, "hm: %d\n", sf_error(sndfile));
+    //perror(error);
+    count  = sf_read_float(sndfile, items, info->frames * info->channels);
+    snprintf(error, (size_t) 61, "count: %d frames: %d channels: %d\n", (int) count, (int) info->frames, info->channels);
+    perror(error);
+
+    if (count == info->frames * info->channels) {
+      sample = (t_sample *) calloc(1, sizeof(t_sample));
+      strncpy(sample->name, samplename, MAXPATHSIZE - 1);
+      sample->info = info;
+      sample->items = items;
+
+    } else {
+      snprintf(error, (size_t) 61, "didn't get the right number of items: %d vs %d %d\n", (int) count, (int) info->frames * info->channels, sf_error(sndfile));
       perror(error);
-      
-      if (count == info->frames * info->channels) {
-        sample = (t_sample *) calloc(1, sizeof(t_sample));
-        strncpy(sample->name, samplename, MAXPATHSIZE - 1);
-        sample->info = info;
-        sample->items = items;
-        samples[sample_count++] = sample;
-      }
-      else {
-	snprintf(error, (size_t) 61, "didn't get the right number of items: %d vs %d %d\n", (int) count, (int) info->frames * info->channels, sf_error(sndfile));
-        perror(error);
-        free(info);
-        free(items);
-      }
-      sf_close(sndfile);
+      free(info);
+      free(items);
     }
-    if (sample == NULL) {
-      printf("failed.\n");
-    }
-    else {
-      fix_samplerate(sample);
-      sample->onsets = NULL;
-      //sample->onsets = segment_get_onsets(sample);
+    sf_close(sndfile);
+  }
+
+  if (sample == NULL) {
+    printf("failed.\n");
+  } else {
+    fix_samplerate(sample);
+    sample->onsets = NULL;
+    //sample->onsets = segment_get_onsets(sample);
+  }
+
+  if (sample) {
+    pthread_mutex_lock(&mutex_samples);
+
+    printf("saving sample %s on index %u\n", samplename, sample_count);
+    samples[sample_count++] = sample;
+
+    pthread_mutex_unlock(&mutex_samples);
+  }
+
+  pthread_mutex_lock(&mutex_loading_file);
+  loading_file = false;
+  pthread_mutex_unlock(&mutex_loading_file);
+
+  free(samplename);
+
+  pthread_exit(NULL);
+}
+
+extern t_sample *file_get(char *samplename) {
+  t_sample *sample;
+
+  if (!mutex_init) {
+    pthread_mutex_init(&mutex_loading_file, NULL);
+    pthread_mutex_init(&mutex_samples, NULL);
+    mutex_init = true;
+  }
+
+  sample = find_sample(samplename);
+
+  if (sample == NULL) {
+    pthread_mutex_lock(&mutex_loading_file);
+    if (!loading_file) {
+      loading_file = true;
+      pthread_mutex_unlock(&mutex_loading_file);
+
+      char* name = malloc(strlen(samplename) + 1);
+      strcpy(name, samplename);
+
+      int rc = pthread_create(&file_thread, NULL, file_read_thr, (void*) name);
+      if (rc) {
+        printf("ERROR. Failed to create file reading thread. Code %d\n", rc);
+        return NULL;
+      }
+    } else {
+      pthread_mutex_unlock(&mutex_loading_file);
     }
   }
 


### PR DESCRIPTION
Whenever Dirt needs to load up a new sample from disk, it now creates a thread for reading and loading sound data into cache. Meanwhile the main thread continues playing, solving the problem with large sample files blocking the main execution thread.

To keep it simple, I made it so that there can only be one thread for file reading (that is, there are no queues), and to enforce that, there is a boolean variable (and its corresponding mutex) that determines if there is actually one running. If there is, skip file loading.

This changeset has a (nice) side effect that makes Dirt play a sample at a specific time *only* if it's already loaded in the samples cache, meaning that the first time you try to play an unloaded sample, it will not actually play until the next "tick" after it's been loaded in the cache. I think this is actually better than the old behavior, because now *it will always play a sample in the right moment*, even if it's delayed a bit more than before (because it used to play just after loading it).