### PR TITLE
[fix] sample load errors

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -81,11 +81,12 @@ static void reset_sound(t_sound* s);
 
 void read_file_func(void* raw_args) {
   read_file_args_t* args = raw_args;
+  t_sample *sample = NULL;
 
-  file_get(args->samplename);
+  sample = file_get(args->samplename);
   unmark_as_loading(args->samplename);
 
-  if (args->play_args) {
+  if (sample && args->play_args) {
     audio_play(args->play_args);
     free_play_args(args->play_args);
   }

--- a/file.c
+++ b/file.c
@@ -108,7 +108,6 @@ extern t_sample *file_get(char *samplename) {
       mutex_samples_init = true;
     }
 
-    t_sample *sample = NULL;
     SNDFILE *sndfile;
     char path[MAXPATHSIZE];
     char error[62];


### PR DESCRIPTION
This fixes an infinite loop within `read_file_func` when a sample file cannot be found.

`file_get` will now __always__ return the loaded sample (from cache or from disk) and __NULL__ only if the file cannot be found.