### PR TITLE
Dirt loop and sample continuation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 
-CFLAGS += -g -I/usr/local/include -Wall -O3 -std=gnu99
-LDFLAGS += -lm -L/usr/local/lib -llo -lsndfile -lsamplerate -lpthread
+CFLAGS += -g -I/usr/local/include -I/opt/local/include -Wall -O3 -std=gnu99
+LDFLAGS += -lm -L/usr/local/lib -L/opt/local/lib -llo -lsndfile -lsamplerate -lpthread
 
 SOURCES=dirt.c common.c audio.c file.c server.c jobqueue.c thpool.c
 OBJECTS=$(SOURCES:.c=.o)

--- a/audio.c
+++ b/audio.c
@@ -674,13 +674,10 @@ extern int audio_play(t_play_args* a) {
 
   new->cut_continue = 0;
   if (a->start < 0) {
-    a->start = -(a->start);
+    a->start = 0;
     new->cut_continue = 1;
   }
-  new->sample_loop = (int) trunc(a->end) - (int) trunc(a->start);
-  a->end = a->end - trunc(a->end - 1e-6); // 1e-6 is so 1.0 stays as 1.0
-  a->start = a->start - trunc(a->start);
-  //printf("loop/start/end: %d\t%f\t%f\n", new->sample_loop, a->start, a->end);
+  new->sample_loop = a->sample_loop;
 
   init_vcf(new);
   init_hpf(new);

--- a/audio.c
+++ b/audio.c
@@ -641,6 +641,7 @@ extern int audio_play(t_play_args* a) {
      new->coarse_ind = 0;
      new->coarse_last = 0;
   }
+  new->sample_loop = a->sample_loop;
 
   init_vcf(new);
   init_hpf(new);
@@ -954,8 +955,12 @@ void playback(float **buffers, int frame, sampletime_t now) {
     tmp = p;
     p = p->next;
     if (tmp->position >= tmp->end || tmp->position < tmp->start) {
-      //printf("remove %s %f\n", tmp->samplename, tmp->position);
-      queue_remove(&playing, tmp);
+      if (--(tmp->sample_loop) > 0) {
+        tmp->position = tmp->start;
+      } else {
+        //printf("remove %s %f\n", tmp->samplename, tmp->position);
+        queue_remove(&playing, tmp);
+      }
     }
   }
 

--- a/audio.c
+++ b/audio.c
@@ -641,7 +641,10 @@ extern int audio_play(t_play_args* a) {
      new->coarse_ind = 0;
      new->coarse_last = 0;
   }
-  new->sample_loop = a->sample_loop;
+  new->sample_loop = (int) trunc(a->end) - (int) trunc(a->start);
+  a->end = a->end - trunc(a->end - 1e-6); // 1e-6 is so 1.0 stays as 1.0
+  a->start = a->start - trunc(a->start);
+  //printf("loop/start/end: %d\t%f\t%f\n", new->sample_loop, a->start, a->end);
 
   init_vcf(new);
   init_hpf(new);

--- a/audio.c
+++ b/audio.c
@@ -173,30 +173,30 @@ void queue_remove(t_sound **queue, t_sound *old) {
 const double coeff[5][11]= {
   { 3.11044e-06,
     8.943665402,    -36.83889529,    92.01697887,    -154.337906,    181.6233289,
-    -151.8651235,   89.09614114,    -35.10298511,    8.388101016,    -0.923313471  
+    -151.8651235,   89.09614114,    -35.10298511,    8.388101016,    -0.923313471
   },
   {4.36215e-06,
-   8.90438318,    -36.55179099,    91.05750846,    -152.422234,    179.1170248,  
+   8.90438318,    -36.55179099,    91.05750846,    -152.422234,    179.1170248,
    -149.6496211,87.78352223,    -34.60687431,    8.282228154,    -0.914150747
   },
   { 3.33819e-06,
     8.893102966,    -36.49532826,    90.96543286,    -152.4545478,    179.4835618,
-    -150.315433,    88.43409371,    -34.98612086,    8.407803364,    -0.932568035  
+    -150.315433,    88.43409371,    -34.98612086,    8.407803364,    -0.932568035
 },
   {1.13572e-06,
-   8.994734087,    -37.2084849,    93.22900521,    -156.6929844,    184.596544,   
+   8.994734087,    -37.2084849,    93.22900521,    -156.6929844,    184.596544,
    -154.3755513,    90.49663749,    -35.58964535,    8.478996281,    -0.929252233
   },
   {4.09431e-07,
-   8.997322763,    -37.20218544,    93.11385476,    -156.2530937,    183.7080141,  
+   8.997322763,    -37.20218544,    93.11385476,    -156.2530937,    183.7080141,
    -153.2631681,    89.59539726,    -35.12454591,    8.338655623,    -0.910251753
   }
 };
 
 float formant_filter(float in, t_sound *sound, int channel) {
-  float res = 
+  float res =
     (float) ( coeff[sound->formant_vowelnum][0] * in +
-              coeff[sound->formant_vowelnum][1] * sound->formant_history[channel][0] +  
+              coeff[sound->formant_vowelnum][1] * sound->formant_history[channel][0] +
               coeff[sound->formant_vowelnum][2] * sound->formant_history[channel][1] +
               coeff[sound->formant_vowelnum][3] * sound->formant_history[channel][2] +
               coeff[sound->formant_vowelnum][4] * sound->formant_history[channel][3] +
@@ -205,7 +205,7 @@ float formant_filter(float in, t_sound *sound, int channel) {
               coeff[sound->formant_vowelnum][7] * sound->formant_history[channel][6] +
               coeff[sound->formant_vowelnum][8] * sound->formant_history[channel][7] +
               coeff[sound->formant_vowelnum][9] * sound->formant_history[channel][8] +
-              coeff[sound->formant_vowelnum][10] * sound->formant_history[channel][9] 
+              coeff[sound->formant_vowelnum][10] * sound->formant_history[channel][9]
              );
 
   sound->formant_history[channel][9] = sound->formant_history[channel][8];
@@ -372,7 +372,7 @@ float effect_coarse(float in, t_sound *sound, int channel) {
     if (crs->index == sound->coarse) {
       crs->index = 0;
       crs->last = in;
-    } 
+    }
   }
   if (sound->coarse < 0) {
     crs->sum += in / (float) -(sound->coarse);
@@ -389,38 +389,38 @@ float effect_coarse(float in, t_sound *sound, int channel) {
 float effect_vcf(float in, t_sound *sound, int channel) {
   t_vcf *vcf = &(sound->vcf[channel]);
   vcf->x  = in - vcf->r * vcf->y4;
-  
+
   vcf->y1 = vcf->x  * vcf->p + vcf->oldx  * vcf->p - vcf->k * vcf->y1;
   vcf->y2 = vcf->y1 * vcf->p + vcf->oldy1 * vcf->p - vcf->k * vcf->y2;
   vcf->y3 = vcf->y2 * vcf->p + vcf->oldy2 * vcf->p - vcf->k * vcf->y3;
   vcf->y4 = vcf->y3 * vcf->p + vcf->oldy3 * vcf->p - vcf->k * vcf->y4;
-  
+
   vcf->y4 = vcf->y4 - pow(vcf->y4,3) / 6;
-  
+
   vcf->oldx  = vcf->x;
   vcf->oldy1 = vcf->y1;
   vcf->oldy2 = vcf->y2;
   vcf->oldy3 = vcf->y3;
-  
+
   return vcf->y4;
 }
 
 float effect_hpf(float in, t_sound *sound, int channel) {
   t_vcf *vcf = &(sound->hpf[channel]);
   vcf->x  = in - vcf->r * vcf->y4;
-  
+
   vcf->y1 = vcf->x  * vcf->p + vcf->oldx  * vcf->p - vcf->k * vcf->y1;
   vcf->y2 = vcf->y1 * vcf->p + vcf->oldy1 * vcf->p - vcf->k * vcf->y2;
   vcf->y3 = vcf->y2 * vcf->p + vcf->oldy2 * vcf->p - vcf->k * vcf->y3;
   vcf->y4 = vcf->y3 * vcf->p + vcf->oldy3 * vcf->p - vcf->k * vcf->y4;
-  
+
   vcf->y4 = vcf->y4 - pow(vcf->y4,3) / 6;
-  
+
   vcf->oldx  = vcf->x;
   vcf->oldy1 = vcf->y1;
   vcf->oldy2 = vcf->y2;
   vcf->oldy3 = vcf->y3;
-  
+
   return (in - vcf->y4);
 }
 
@@ -431,7 +431,7 @@ float effect_bpf(float in, t_sound *sound, int channel) {
   vcf->y3 = vcf->p * vcf->y2 - vcf->y1 + vcf->k * (vcf->x - vcf->oldx +
         vcf->y2);
   vcf->y3 = vcf->scale * vcf->y3;
-  
+
   vcf->oldx  = vcf->x;
   vcf->y1 = vcf->y2;
   vcf->y2 = vcf->y3;
@@ -461,15 +461,15 @@ float shift_delay(t_line *line) {
 
 /**/
 
-extern void audio_kriole(double when, 
-                         float duration, 
-                         float pitch_start, 
+extern void audio_kriole(double when,
+                         float duration,
+                         float pitch_start,
                          float pitch_stop
 			 ) {
 #ifdef FEEDBACK
-  
+
   int lowchunk = loop->chunk_n - (loop->frames / loop->chunksz);
-  
+
   // subtract a bit for some legroom..
   lowchunk -= 16;
 
@@ -572,13 +572,13 @@ extern int audio_play(t_play_args* a) {
   new->active = 1;
   //printf("samplename: %s when: %f\n", a->samplename, a->when);
   strncpy(new->samplename, a->samplename, MAXPATHSIZE);
-  
+
 #ifdef FEEDBACK
   if (is_kriole) {
     new->loop    = loop;
     //printf("calculating chunk %d\n", a->kriole_chunk);
     new->kriole_chunk = a->kriole_chunk;
-    
+
     //printf("now %d\n", loop->now);
     //printf("since_chunk %d\n", loop->since_chunk);
     int last_chunk_start = (loop->now - loop->since_chunk);
@@ -611,7 +611,7 @@ extern int audio_play(t_play_args* a) {
 #endif
 
 #ifdef JACK
-  new->startT = 
+  new->startT =
     jack_time_to_frames(jack_client, ((a->when-epochOffset) * 1000000));
 # else
   new->startT = a->when - epochOffset;
@@ -625,9 +625,9 @@ extern int audio_play(t_play_args* a) {
     a->accelerate = a->accelerate * a->speed * a->cps; // change rate by 1 per cycle
     a->speed = sample->info->frames * a->speed * a->cps / samplerate;
   }
-  // otherwise, unit is rate/ratio, 
+  // otherwise, unit is rate/ratio,
   // i.e. 2 = twice as fast, -1 = normal but backwards
-   
+
   new->next = NULL;
   new->prev = NULL;
   new->reverse  = a->speed < 0;
@@ -672,6 +672,11 @@ extern int audio_play(t_play_args* a) {
   new->coarse = a->coarse;
   init_crs(new);
 
+  new->cut_continue = 0;
+  if (a->start < 0) {
+    a->start = -(a->start);
+    new->cut_continue = 1;
+  }
   new->sample_loop = (int) trunc(a->end) - (int) trunc(a->start);
   a->end = a->end - trunc(a->end - 1e-6); // 1e-6 is so 1.0 stays as 1.0
   a->start = a->start - trunc(a->start);
@@ -703,7 +708,7 @@ extern int audio_play(t_play_args* a) {
   if (a->start > 0 && a->start <= 1) {
     new->start = a->start * new->end;
   }
-  
+
   if (a->end > 0 && a->end < 1) {
     new->end *= a->end;
   }
@@ -719,6 +724,7 @@ extern int audio_play(t_play_args* a) {
   //printf("position: %f\n", new->position);
   new->formant_vowelnum = a->vowelnum;
   new->gain = powf(a->gain/2, 4);
+
 
   pthread_mutex_lock(&queue_waiting_lock);
   queue_add(&waiting, new);
@@ -758,7 +764,15 @@ void cut(t_sound *s) {
         // unless it's dying soon anyway..
         if (newend < p->end) {
           p->end = newend;
+          // cut_continue means start the next where the prev is leaving off
+          if (s->cut_continue > 0 && p->position < s->end) {
+            s->start = p->position;
+            s->position = p->position;
+            s->cut_continue = 0;
+          }
         }
+        // cut should also kill any looping
+        p->sample_loop = 0;
       }
       p = p->next;
     }
@@ -772,7 +786,7 @@ void dequeue(sampletime_t now) {
 #ifdef DEBUG
     int s = queue_size(playing);
 #endif
-    
+
     cut(p);
     p->prev = NULL;
     p->next = playing;
@@ -783,7 +797,7 @@ void dequeue(sampletime_t now) {
 #ifdef DEBUG
     assert(s == (queue_size(playing) - 1));
 #endif
-    
+
     //printf("done.\n");
   }
   pthread_mutex_unlock(&queue_waiting_lock);
@@ -804,10 +818,10 @@ float compressdave(float in) {
   float result = in;
   // square input (to abs and make logarithmic)
   float t=in*in;
-  
+
   // blend to create simple envelope follower
   env = env*(1-compression_speed) + t*compression_speed;
-  
+
   // if we are over the threshold
   if (env > threshold) {
     // calculate the gain related to amount over thresh
@@ -829,7 +843,7 @@ void playback(float **buffers, int frame, sampletime_t now) {
   while (p != NULL) {
     int channels;
     t_sound *tmp;
-    
+
     if (p->startT > now) {
       p->checks++;
       p = p->next;
@@ -869,7 +883,7 @@ void playback(float **buffers, int frame, sampletime_t now) {
 #else
       if (pos < p->end) {
 #endif
-        float next = 
+        float next =
           p->items[(channels * (p->reverse ? p->sample->info->frames - pos : pos))
                     + channel
                     ];
@@ -884,11 +898,11 @@ void playback(float **buffers, int frame, sampletime_t now) {
       }
 
       // why 44000 (or 44100)? init_vcf divides by samplerate..
-      if (p->resonance > 0 && p->resonance < 1 
+      if (p->resonance > 0 && p->resonance < 1
 	  && p->cutoff > 0 && p->cutoff < 1) {
 	value = effect_vcf(value, p, channel);
       }
-      if (p->hresonance > 0 && p->hresonance < 1 
+      if (p->hresonance > 0 && p->hresonance < 1
           && p->hcutoff > 0 && p->hcutoff < 1) {
         value = effect_hpf(value, p, channel);
       }
@@ -960,7 +974,7 @@ void playback(float **buffers, int frame, sampletime_t now) {
         break;
       }
     }
-      
+
     if (p->accelerate != 0) {
       // ->startFrame ->end ->position
       p->speed += p->accelerate/samplerate;
@@ -1023,7 +1037,7 @@ void loop_input(float s) {
       float pitch = extracted[0];
       float flux = extracted[1];
       float centroid = extracted[2];
-      
+
       if (pitch >= 0) {
         osc_send_pitch(starttime, loop->chunk_n, pitch, flux, centroid);
       }
@@ -1040,12 +1054,12 @@ extern int jack_callback(int frames, float *input, float **outputs) {
 
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    epochOffset = ((double) tv.tv_sec + ((double) tv.tv_usec / 1000000.0)) 
+    epochOffset = ((double) tv.tv_sec + ((double) tv.tv_usec / 1000000.0))
       - ((double) jack_get_time() / 1000000.0);
     //printf("jack time: %d tv_sec %d epochOffset: %f\n", jack_get_time(), tv.tv_sec, epochOffset);
 
   now = jack_last_frame_time(jack_client);
-  
+
   for (int i=0; i < frames; ++i) {
     playback(outputs, i, now + i);
 
@@ -1083,23 +1097,23 @@ void run_pulse() {
   pa_simple *s = NULL;
   //  int ret = 1;
   int error;
-  if (!(s = pa_simple_new(NULL, "dirt", PA_STREAM_PLAYBACK, NULL, 
+  if (!(s = pa_simple_new(NULL, "dirt", PA_STREAM_PLAYBACK, NULL,
     "playback", &ss, NULL, NULL, &error))) {
-    fprintf(stderr, __FILE__": pa_simple_new() failed: %s\n", 
+    fprintf(stderr, __FILE__": pa_simple_new() failed: %s\n",
     pa_strerror(error));
     goto finish;
   }
 
   for (;;) {
-    
+
     pa_usec_t latency;
     if ((latency = pa_simple_get_latency(s, &error)) == (pa_usec_t) -1) {
-      fprintf(stderr, __FILE__": pa_simple_get_latency() failed: %s\n", 
+      fprintf(stderr, __FILE__": pa_simple_get_latency() failed: %s\n",
 	      pa_strerror(error));
       goto finish;
     }
     //fprintf(stderr, "%f sec    \n", ((float)latency)/1000000.0);
-    
+
     gettimeofday(&tv, NULL);
     double now = ((double) tv.tv_sec + ((double) tv.tv_usec / 1000000.0));
 
@@ -1111,7 +1125,7 @@ void run_pulse() {
       }
       dequeue(framenow);
     }
-    
+
     if (pa_simple_write(s, interlaced, sizeof(interlaced), &error) < 0) {
       fprintf(stderr, __FILE__": pa_simple_write() failed: %s\n", pa_strerror(error));
       goto finish;
@@ -1137,7 +1151,7 @@ static int pa_callback(const void *inputBuffer, void *outputBuffer,
 		       const PaStreamCallbackTimeInfo* timeInfo,
 		       PaStreamCallbackFlags statusFlags,
 		       void *userData) {
-  
+
   struct timeval tv;
 
   if (epochOffset == 0) {
@@ -1170,7 +1184,7 @@ void preload_kriol(char *dir) {
   snprintf(path, MAXPATHSIZE -1, "%s/%s", SAMPLEROOT, dir);
   n = scandir(path, &namelist, wav_filter, alphasort);
   for (int i = 0; i < n; ++i) {
-    snprintf(path, MAXPATHSIZE -1, 
+    snprintf(path, MAXPATHSIZE -1,
              "kriol_preload/%s", namelist[i]->d_name
              );
     t_sample *sample = file_get(path);
@@ -1249,7 +1263,7 @@ void pa_init(void) {
   }
   printf("default device: %s\n", Pa_GetDeviceInfo(outputParameters.device)->name);
   outputParameters.channelCount = g_num_channels;
-  outputParameters.sampleFormat = paFloat32 | paNonInterleaved; 
+  outputParameters.sampleFormat = paFloat32 | paNonInterleaved;
   outputParameters.suggestedLatency = 0.050;
   // Pa_GetDeviceInfo( outputParameters.device )->defaultLowOutputLatency;
   outputParameters.hostApiSpecificStreamInfo = NULL;
@@ -1262,22 +1276,22 @@ void pa_init(void) {
             samplerate,
             PA_FRAMES_PER_BUFFER,
             paNoFlag,
-            pa_callback, 
+            pa_callback,
             (void *) foo );
     if( err != paNoError ) {
       printf("failed to open stream.\n");
       goto error;
-    } 
+    }
 
     err = Pa_SetStreamFinishedCallback( stream, &StreamFinished );
     if( err != paNoError ) {
       goto error;
-    } 
+    }
 
     err = Pa_StartStream(stream);
     if( err != paNoError ) {
       goto error;
-    } 
+    }
 
   return;
 error:

--- a/audio.h
+++ b/audio.h
@@ -98,6 +98,7 @@ typedef struct t_node {
   float  bandq;
   t_vcf  *bpf;
   int    sample_loop;
+  int    cut_continue;
 } t_sound;
 
 typedef struct {

--- a/audio.h
+++ b/audio.h
@@ -129,6 +129,7 @@ typedef struct {
   float bandf;
   float bandq;
   char unit;
+  int sample_loop;
 } t_play_args;
 
 

--- a/audio.h
+++ b/audio.h
@@ -37,6 +37,12 @@ typedef struct {
 } t_vcf;
 
 typedef struct {
+  int index;
+  float last;
+  float sum;
+} t_crs;
+
+typedef struct {
   float samples[MAXLINE];
   int   point;
 } t_line;
@@ -84,9 +90,7 @@ typedef struct t_node {
   int    crush;
   float  crush_bits;
   int    coarse;
-  int    coarse_ind;
-  float  coarse_last;
-  float  coarse_sum;
+  t_crs  *coarsef;
   float  hcutoff;
   float  hresonance;
   t_vcf  *hpf;

--- a/audio.h
+++ b/audio.h
@@ -124,7 +124,6 @@ typedef struct {
   float bandf;
   float bandq;
   char unit;
-  int sample_loop;
 } t_play_args;
 
 

--- a/audio.h
+++ b/audio.h
@@ -93,6 +93,7 @@ typedef struct t_node {
   float  bandf;
   float  bandq;
   t_vcf  *bpf;
+  int    sample_loop;
 } t_sound;
 
 typedef struct {
@@ -123,6 +124,7 @@ typedef struct {
   float bandf;
   float bandq;
   char unit;
+  int sample_loop;
 } t_play_args;
 
 

--- a/server.c
+++ b/server.c
@@ -127,8 +127,9 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   float bandq = argc > (23+poffset) ? argv[23+poffset]->f : 0;
 
   char *unit_name = argc > (24+poffset) ? (char *) argv[24+poffset] : "r";
+  int sample_loop = argc > (25+poffset) ? argv[25+poffset]->i : 0;
 
-  if (argc > 25+poffset) {
+  if (argc > 26+poffset) {
     printf("play server unexpectedly received extra parameters, maybe update Dirt?\n");
   }
 
@@ -180,7 +181,8 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
     hresonance,
     bandf,
     bandq,
-    unit
+    unit,
+    sample_loop
   };
   audio_play(&args);
   free(sample_name);
@@ -243,6 +245,11 @@ void *zmqthread(void *data){
 extern int server_init(void) {
 
   lo_server_thread st = lo_server_thread_new(OSC_PORT, error);
+
+  lo_server_thread_add_method(st, "/play", "iisffffffsffffififfffifffffi",
+                              play_handler, 
+                              NULL
+                             );
 
   lo_server_thread_add_method(st, "/play", "iisffffffsffffififfffifffff",
                               play_handler, 

--- a/server.c
+++ b/server.c
@@ -127,8 +127,9 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   float bandq = argc > (23+poffset) ? argv[23+poffset]->f : 0;
 
   char *unit_name = argc > (24+poffset) ? (char *) argv[24+poffset] : "r";
+  int sample_loop = argc >  (25+poffset) ? argv[25+poffset]->i : 0;
 
-  if (argc > 25+poffset) {
+  if (argc > 26+poffset) {
     printf("play server unexpectedly received extra parameters, maybe update Dirt?\n");
   }
 
@@ -180,7 +181,8 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
     hresonance,
     bandf,
     bandq,
-    unit
+    unit,
+    sample_loop
   };
   audio_play(&args);
   free(sample_name);
@@ -243,6 +245,11 @@ void *zmqthread(void *data){
 extern int server_init(void) {
 
   lo_server_thread st = lo_server_thread_new(OSC_PORT, error);
+
+  lo_server_thread_add_method(st, "/play", "iisffffffsffffififfffifffffi",
+                              play_handler, 
+                              NULL
+                             );
 
   lo_server_thread_add_method(st, "/play", "iisffffffsffffififfffifffff",
                               play_handler, 

--- a/server.c
+++ b/server.c
@@ -127,9 +127,8 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   float bandq = argc > (23+poffset) ? argv[23+poffset]->f : 0;
 
   char *unit_name = argc > (24+poffset) ? (char *) argv[24+poffset] : "r";
-  int sample_loop = argc > (25+poffset) ? argv[25+poffset]->i : 0;
 
-  if (argc > 26+poffset) {
+  if (argc > 25+poffset) {
     printf("play server unexpectedly received extra parameters, maybe update Dirt?\n");
   }
 
@@ -181,8 +180,7 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
     hresonance,
     bandf,
     bandq,
-    unit,
-    sample_loop
+    unit
   };
   audio_play(&args);
   free(sample_name);
@@ -245,11 +243,6 @@ void *zmqthread(void *data){
 extern int server_init(void) {
 
   lo_server_thread st = lo_server_thread_new(OSC_PORT, error);
-
-  lo_server_thread_add_method(st, "/play", "iisffffffsffffififfffifffffi",
-                              play_handler, 
-                              NULL
-                             );
 
   lo_server_thread_add_method(st, "/play", "iisffffffsffffififfffifffff",
                               play_handler, 


### PR DESCRIPTION
This adds sample looping and a few other tweaks

1. Looping, using the parameter `loop` in Tidal.  Loops the sample the specified number of times, respecting `begin`, `end`, `speed`, etc.
2. Bugfix for `coarse` – it now properly deals with multichannel (including stereo) audio.
3. Negative values for `begin`, when used with a cut group, tell Dirt to start sample playback from the current playback position of the cut sample, i.e. continue playback from where it left off. One big use of this is to change other parameters (such as `cutoff` or `coarse`) while a long sample is playing:
```
cps 0.5
d1 $ sound "breaks125*4" |+| unit "c" |+| cut "-1" |+| begin "-1" |+| coarse (slow 2 $ "1 2 4 8 16 32 64 128")
```