### PR TITLE
[++] restore original Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 
-CFLAGS += -g -I/usr/local/include -I/opt/local/include -Wall -O3 -std=gnu99
-LDFLAGS += -lm -L/usr/local/lib -L/opt/local/lib -llo -lsndfile -lsamplerate -lpthread
+CFLAGS += -g -I/usr/local/include -Wall -O3 -std=gnu99
+LDFLAGS += -lm -L/usr/local/lib -llo -lsndfile -lsamplerate -lpthread
 
 SOURCES=dirt.c common.c audio.c file.c server.c jobqueue.c thpool.c
 OBJECTS=$(SOURCES:.c=.o)


### PR DESCRIPTION
Though this still not avoids accidental local changes to Makefile getting pushed to upstream, this reverts latest changes to original state (no -I/opt/local/include).

One can however use `git update-index --assume-unchanged Makefile` to temporarily ignore changes to Makefile. [Though caveats should be honoured](http://gitready.com/intermediate/2009/02/18/temporarily-ignoring-files.html)