### PR TITLE
Fix segment fault when jack_get_ports returns NULL

### DIFF
--- a/jack.c
+++ b/jack.c
@@ -121,25 +121,33 @@ extern jack_client_t *jack_start(t_callback callback, bool autoconnect) {
     const char **ports;
     ports = jack_get_ports(client, NULL, NULL,
                            JackPortIsPhysical|JackPortIsInput);
-    for (i = 0; i < g_num_channels; ++i) {
-      if (ports[i] == NULL) {
-        break;
+    if (!ports) {
+      fprintf(stderr, "cannot find any physical capture ports\n");
+    } else {
+      for (i = 0; i < g_num_channels; ++i) {
+        if (ports[i] == NULL) {
+          break;
+        }
+        //sprintf(portname, "output_%d", i);
+        if (jack_connect(client, jack_port_name(output_ports[i]), ports[i])) {
+          fprintf(stderr, "cannot connect output ports\n");
+        }
       }
-      //sprintf(portname, "output_%d", i);
-      if (jack_connect(client, jack_port_name(output_ports[i]), ports[i])) {
-        fprintf(stderr, "cannot connect output ports\n");
-      }
+      free(ports);
     }
-    free(ports);
 
 #ifdef INPUT
     ports = jack_get_ports(client, NULL, NULL,
                            JackPortIsPhysical|JackPortIsOutput);
     //strcpy(portname, "input");
-    if (jack_connect(client, ports[0], jack_port_name(input_port))) {
-      fprintf(stderr, "cannot connect input port\n");
+    if (!ports) {
+      fprintf(stderr, "cannot find any physical capture ports\n");
+    } else {
+      if (jack_connect(client, ports[0], jack_port_name(input_port))) {
+        fprintf(stderr, "cannot connect input port\n");
+      }
+      free(ports);
     }
-    free(ports);
 #endif
   }
 


### PR DESCRIPTION
This fixes segment fault when jack_get_ports returns NULL because jack cannot find any physical capture ports.