### PR TITLE
Display version with -v flag

### DIFF
--- a/dirt.c
+++ b/dirt.c
@@ -21,6 +21,7 @@ int main (int argc, char **argv) {
   int num_channels;
   char *osc_port = DEFAULT_OSC_PORT;
   char *sampleroot = "./samples";
+  char *version = "1.0.0";
 
   unsigned int num_workers = DEFAULT_WORKERS;
 
@@ -70,6 +71,8 @@ int main (int argc, char **argv) {
         if (long_options[option_index].flag != 0) break;
 
       case 'v':
+        printf("%s\n", version);
+        return 1;
       case 'h':
         printf("Usage: dirt [OPTION]...\n"
                "\n"


### PR DESCRIPTION
Hello all!

Thought I'd start on the road to contributing with an easy one that deserves a tiny bit of conversation.

Issue #32 raises a good point - the `--version` flag doesn't work. Is there a versioning protocol in place? I see there's a `1.0` tag, but seems that was two years ago.

Would be good to add _something_ as a version, even if arbitrary to begin with, then we can incrementally update as we go. Removing the sample directory seems like a big step for the version number!

Let me know if there's a better way of displaying the version - I'm fairly new to C but excited to contribute!