### PR TITLE
Fix -c segfault

### DIFF
--- a/dirt.c
+++ b/dirt.c
@@ -58,7 +58,7 @@ int main (int argc, char **argv) {
       required_argument: ":"
       optional_argument: "::" */
 
-    c = getopt_long(argc, argv, "cs:w:vh",
+    c = getopt_long(argc, argv, "c:s:w:vh",
                     long_options, &option_index);
 
     if (c == -1)


### PR DESCRIPTION
The -c flag wasn't marked as a required argument in getopt's shortopts.

Fixes #38.