### PR TITLE
command line option for gain, gain comp for shape

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -57,6 +57,7 @@ float delay_feedback = 0.7;
 
 bool use_dirty_compressor = false;
 bool use_late_trigger = false;
+bool use_shape_gain_comp = false;
 
 thpool_t* read_file_pool;
 
@@ -917,8 +918,10 @@ void playback(float **buffers, int frame, sampletime_t now) {
       if (p->shape) {
         value = (1+p->shape_k)*value/(1+p->shape_k*fabs(value));
         // gain compensation, fine-tuned by ear
-        float gcomp = 1.0 - (0.15 * p->shape_k / (p->shape_k + 2.0));
-        value *= gcomp * gcomp;
+        if (use_shape_gain_comp) {
+          float gcomp = 1.0 - (0.15 * p->shape_k / (p->shape_k + 2.0));
+          value *= gcomp * gcomp;
+        }
       }
       if (p->crush > 0) {
         //value = (1.0 + log(fabs(value)) / 16.63553) * (value / fabs(value));
@@ -1277,7 +1280,7 @@ error:
 }
 #endif
 
- extern void audio_init(bool dirty_compressor, bool autoconnect, bool late_trigger, unsigned int num_workers, char *sroot) {
+ extern void audio_init(bool dirty_compressor, bool autoconnect, bool late_trigger, unsigned int num_workers, char *sroot, bool shape_gain_comp) {
   struct timeval tv;
 
   atexit(audio_close);
@@ -1326,6 +1329,7 @@ error:
 
   use_dirty_compressor = dirty_compressor;
   use_late_trigger = late_trigger;
+  use_shape_gain_comp = shape_gain_comp;
 }
 
 extern void audio_close(void) {

--- a/audio.c
+++ b/audio.c
@@ -916,6 +916,9 @@ void playback(float **buffers, int frame, sampletime_t now) {
 
       if (p->shape) {
         value = (1+p->shape_k)*value/(1+p->shape_k*fabs(value));
+        // gain compensation, fine-tuned by ear
+        float gcomp = 1.0 - (0.15 * p->shape_k / (p->shape_k + 2.0));
+        value *= gcomp * gcomp;
       }
       if (p->crush > 0) {
         //value = (1.0 + log(fabs(value)) / 16.63553) * (value / fabs(value));
@@ -999,11 +1002,11 @@ void playback(float **buffers, int frame, sampletime_t now) {
     }
     float factor = compress(max);
     for (channel = 0; channel < g_num_channels; ++channel) {
-      buffers[channel][frame] *= factor * 0.4;
+      buffers[channel][frame] *= factor * g_gain/5.0;
     }
   } else {
     for (channel = 0; channel < g_num_channels; ++channel) {
-      buffers[channel][frame] *= 2;
+      buffers[channel][frame] *= g_gain;
     }
   }
 }

--- a/audio.h
+++ b/audio.h
@@ -135,7 +135,7 @@ typedef struct {
 
 
 extern int audio_callback(int frames, float *input, float **outputs);
-extern void audio_init(bool dirty_compressor, bool autoconnect, bool late_trigger, unsigned int num_workers, char *sampleroot);
+extern void audio_init(bool dirty_compressor, bool autoconnect, bool late_trigger, unsigned int num_workers, char *sampleroot, bool shape_gain_comp);
 extern void audio_close(void);
 extern int audio_play(t_play_args*);
 

--- a/common.c
+++ b/common.c
@@ -2,3 +2,4 @@
 #include "config.h"
 
 int g_num_channels = DEFAULT_CHANNELS;
+float g_gain = DEFAULT_GAIN;

--- a/common.h
+++ b/common.h
@@ -6,5 +6,6 @@
 #define bool _Bool
 
 extern int g_num_channels;
+extern float g_gain;
 
 #endif // __COMMON_H__

--- a/config.h
+++ b/config.h
@@ -8,6 +8,7 @@
 #define DEFAULT_CHANNELS 2
 #define MIN_CHANNELS 1
 #define MAX_CHANNELS 16
+#define DEFAULT_GAIN 2.0
 
 #define DEFAULT_WORKERS 4
 

--- a/dirt.c
+++ b/dirt.c
@@ -14,6 +14,7 @@ static int dirty_compressor_flag = 1;
 static int jack_auto_connect_flag = 1;
 #endif
 static int late_trigger_flag = 1;
+static int shape_gain_comp_flag = 0;
 
 int main (int argc, char **argv) {
   /* Use getopt to parse command-line arguments */
@@ -38,6 +39,8 @@ int main (int argc, char **argv) {
       {"channels",              required_argument, 0, 'c'},
       {"dirty-compressor",      no_argument, &dirty_compressor_flag, 1},
       {"no-dirty-compressor",   no_argument, &dirty_compressor_flag, 0},
+      {"shape-gain-compensation",      no_argument, &shape_gain_comp_flag, 1},
+      {"no-shape-gain-compensation",   no_argument, &shape_gain_comp_flag, 0},
 #ifdef JACK
       {"jack-auto-connect",     no_argument, &jack_auto_connect_flag, 1},
       {"no-jack-auto-connect",  no_argument, &jack_auto_connect_flag, 0},
@@ -84,21 +87,23 @@ int main (int argc, char **argv) {
                "Released as free software under the terms of the GNU Public License version 3.0 and later.\n"
                "\n"
                "Arguments:\n"
-	       "  -p, --port                      OSC port to listen to (default: %s)\n"
-               "  -c, --channels                  number of output channels (default: %u)\n"
-               "      --dirty-compressor          enable dirty compressor on audio output (default)\n"
-               "      --no-dirty-compressor       disable dirty compressor on audio output\n"
-               "  -g, --gain                      gain adjustment (default %f db)\n"
+	             "  -p, --port                       OSC port to listen to (default: %s)\n"
+               "  -c, --channels                   number of output channels (default: %u)\n"
+               "      --dirty-compressor           enable dirty compressor on audio output (default)\n"
+               "      --no-dirty-compressor        disable dirty compressor on audio output\n"
+               "      --shape-gain-compensation    enable distortion gain compensation\n"
+               "      --no-shape-gain-compensation disable distortion gain compensation (default)\n"
+               "  -g, --gain                       gain adjustment (default %f db)\n"
 #ifdef JACK
-               "      --jack-auto-connect         automatically connect to writable clients (default)\n"
-               "      --no-jack-auto-connect      do not connect to writable clients  \n"
+               "      --jack-auto-connect          automatically connect to writable clients (default)\n"
+               "      --no-jack-auto-connect       do not connect to writable clients  \n"
 #endif
-               "      --late-trigger              enable sample retrigger after loading (default)\n"
-               "      --no-late-trigger           disable sample retrigger after loading\n"
-	       "  -s  --samples-root-path         set a samples root directory path\n"
-               "  -w, --workers                   number of sample-reading workers (default: %u)\n"
-               "  -h, --help                      display this help and exit\n"
-               "  -v, --version                   output version information and exit\n",
+               "      --late-trigger               enable sample retrigger after loading (default)\n"
+               "      --no-late-trigger            disable sample retrigger after loading\n"
+	             "  -s  --samples-root-path          set a samples root directory path\n"
+               "  -w, --workers                    number of sample-reading workers (default: %u)\n"
+               "  -h, --help                       display this help and exit\n"
+               "  -v, --version                    output version information and exit\n",
                DEFAULT_OSC_PORT, DEFAULT_CHANNELS,
                20.0*log10(DEFAULT_GAIN/16.0),
                DEFAULT_WORKERS);
@@ -151,6 +156,9 @@ int main (int argc, char **argv) {
   if (!dirty_compressor_flag) {
     fprintf(stderr, "dirty compressor disabled\n");
   }
+  if (shape_gain_comp_flag) {
+    fprintf(stderr, "distortion gain compensation enabled\n");
+  }
 
 #ifdef JACK
   if (!jack_auto_connect_flag) {
@@ -166,9 +174,9 @@ int main (int argc, char **argv) {
 
   fprintf(stderr, "init audio\n");
 #ifdef JACK
-  audio_init(dirty_compressor_flag, jack_auto_connect_flag, late_trigger_flag, num_workers, sampleroot);
+  audio_init(dirty_compressor_flag, jack_auto_connect_flag, late_trigger_flag, num_workers, sampleroot, shape_gain_comp_flag);
 #else
-  audio_init(dirty_compressor_flag, true, late_trigger_flag, num_workers, sampleroot);
+  audio_init(dirty_compressor_flag, true, late_trigger_flag, num_workers, sampleroot, shape_gain_comp_flag);
 #endif
 
   fprintf(stderr, "init open sound control\n");

--- a/server.c
+++ b/server.c
@@ -132,8 +132,10 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   char *unit_name = argc > (24+poffset) ? (char *) argv[24+poffset] : "r";
   int sample_loop = argc >  (25+poffset) ? argv[25+poffset]->i : 0;
 
-  if (argc > 26+poffset) {
+  static bool extraWarned = false;
+  if (argc > 26+poffset && !extraWarned) {
     printf("play server unexpectedly received extra parameters, maybe update Dirt?\n");
+    extraWarned = true;
   }
 
   if (speed == 0) {


### PR DESCRIPTION
I added a command line option “-g, —gain” to change the overall gain of
Dirt when starting it up.  This applies regardless of whether the dirty
compression is turned on or off.  It should default to the old values.
The argument is given in dB from peak.

I also included some gain compensation for the “shape” parameter, so
the distortion doesn’t just increase the loudness. The compensation is
based on “typical” sounds, so results may vary, and it breaks down when
the shape parameter is near 1.

Finally, I made a small fix to server.c to avoid message spam when Dirt
receives extra OSC params.