### PR TITLE
Fix for sound vs s & n params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 
-CFLAGS += -g -I/usr/local/include -Wall -O3 -std=gnu99
-LDFLAGS += -lm -L/usr/local/lib -llo -lsndfile -lsamplerate -lpthread
+CFLAGS += -g -I/usr/local/include -I/opt/local/include -Wall -O3 -std=gnu99
+LDFLAGS += -lm -L/usr/local/lib -L/opt/local/lib -llo -lsndfile -lsamplerate -lpthread
 
 SOURCES=dirt.c common.c audio.c file.c server.c jobqueue.c thpool.c
 OBJECTS=$(SOURCES:.c=.o)

--- a/audio.c
+++ b/audio.c
@@ -511,8 +511,21 @@ extern int audio_play(t_play_args* a) {
 #ifdef FEEDBACK
   int is_loop = 0;
 #endif
+  t_sound *new;
+  new = new_sound();
+  if (new == NULL) {
+    printf("hit max sounds (%d)\n", MAXSOUNDS);
+    return(-1);
+  }
+  new->active = 1;
 
   t_sample *sample = NULL;
+  if (a->sample_n) {
+    snprintf(new->samplename, MAXPATHSIZE, "%s:%d", a->samplename, a->sample_n);
+  }
+  else {
+    strncpy(new->samplename, a->samplename, MAXPATHSIZE);
+  }
 
 #ifdef FEEDBACK
   if (strcmp(a->samplename, "loop") == 0) {
@@ -520,22 +533,22 @@ extern int audio_play(t_play_args* a) {
   }
   else {
 #endif
-    sample = file_get_from_cache(a->samplename);
+    sample = file_get_from_cache(new->samplename);
 
     if (sample == NULL) {
-      if (!is_sample_loading(a->samplename)) {
-        mark_as_loading(a->samplename);
+      if (!is_sample_loading(new->samplename)) {
+        mark_as_loading(new->samplename);
 
         read_file_args_t* args = malloc(sizeof(read_file_args_t));
         if (!args) {
           fprintf(stderr, "audio_play: Could not allocate memory for read_file_args_t\n");
           return 0;
         }
-        args->samplename = strdup(a->samplename);
+        args->samplename = strdup(new->samplename);
         args->play_args = use_late_trigger ? copy_play_args(a) : NULL;
 
         if (!thpool_add_job(read_file_pool, (void*) read_file_func, (void*) args)) {
-          fprintf(stderr, "audio_play: Could not add file reading job for '%s'\n", a->samplename);
+          fprintf(stderr, "audio_play: Could not add file reading job for '%s'\n", new->samplename);
         }
       }
 
@@ -544,8 +557,6 @@ extern int audio_play(t_play_args* a) {
 #ifdef FEEDBACK
   }
 #endif
-
-  t_sound *new;
 
   if (a->delay > 1) {
     a->delay = 1;
@@ -563,21 +574,7 @@ extern int audio_play(t_play_args* a) {
     a->delayfeedback = 0;
   }
 
-  new = new_sound();
-  if (new == NULL) {
-    printf("hit max sounds (%d)\n", MAXSOUNDS);
-    return(-1);
-  }
-
-  new->active = 1;
   //printf("samplename: %s when: %f\n", a->samplename, a->when);
-
-  if (a->sample_n) {
-    snprintf(new->samplename, MAXPATHSIZE, "%s:%d", a->samplename, a->sample_n);
-  }
-  else {
-    strncpy(new->samplename, a->samplename, MAXPATHSIZE);
-  }
 
 #ifdef FEEDBACK
   if (is_loop) {


### PR DESCRIPTION
The change to the `samplename` wasn’t actually happening until after
the file was loaded, which resulted in “sound” not working properly.
So I’ve moved some code to the beginning of audio_play to fix this.