### PR TITLE
adds support for attack-hold-release envelope

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -103,6 +103,10 @@ typedef struct t_node {
   char   unit;
   float  cps;
   double when;
+  float  attack;
+  float  hold;
+  float  release;
+  float  playtime;
 } t_sound;
 
 typedef struct {
@@ -135,6 +139,9 @@ typedef struct {
   char unit;
   int sample_loop;
   int sample_n;
+  float attack;
+  float hold;
+  float release;
 } t_play_args;
 
 

--- a/server.c
+++ b/server.c
@@ -100,8 +100,12 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   int sample_loop = argc > (25+poffset) ? argv[25+poffset]->i : 0;
   int sample_n = argc > (26+poffset) ? argv[26+poffset]->i : 0;
 
+  float attack = argc > (27+poffset) ? argv[27+poffset]->f : 0;
+  float hold = argc > (28+poffset) ? argv[28+poffset]->f : 0;
+  float release = argc > (29+poffset) ? argv[29+poffset]->f : 0;
+
   static bool extraWarned = false;
-  if (argc > 27+poffset && !extraWarned) {
+  if (argc > 30+poffset && !extraWarned) {
     printf("play server unexpectedly received extra parameters, maybe update Dirt?\n");
     extraWarned = true;
   }
@@ -173,6 +177,9 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   else {
     strncpy(sound->samplename, sample_name, MAXPATHSIZE);
   }
+  sound->attack = attack;
+  sound->hold = hold;
+  sound->release = release;
 
   audio_play(sound);
 


### PR DESCRIPTION
new params `attack` `hold` and `release` are defined.  `attack` and
`release` must be specified (>= 0) for the envelope to take effect,
`hold` time defaults to zero.  For example, `d1 $ sound "rave" # attack
"0.1" # release "0.2"` will play the sample with an attack time of 0.1 seconds and an instant release of 0.2 seconds.