### PR TITLE
wav_filter method to use strcasecmp instead of strcmp

### DIFF
--- a/file.c
+++ b/file.c
@@ -57,9 +57,7 @@ t_sample *find_sample (char *samplename) {
 
 int wav_filter (const struct dirent *d) {
   if (strlen(d->d_name) > 4) {
-    return(strcmp(d->d_name + strlen(d->d_name) - 4, ".wav") == 0
-           || strcmp(d->d_name + strlen(d->d_name) - 4, ".WAV") == 0
-           );
+    return(strcasecmp(d->d_name + strlen(d->d_name) - 4, ".wav") == 0);
   }
   return(0);
 }


### PR DESCRIPTION
Corrects the issue of using nested strcmp's to find a valid wav by instead using the cleaner strcasecmp method. 

This is a simple fix intended to simply open some dialogue about contributing to the development of Tidal.