### PR TITLE
Change `loop` to float

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -98,7 +98,7 @@ typedef struct t_node {
   float  bandf;
   float  bandq;
   t_vcf  *bpf;
-  int    sample_loop;
+  float  sample_loop;
   int    cut_continue;
   char   unit;
   float  cps;
@@ -137,7 +137,7 @@ typedef struct {
   float bandf;
   float bandq;
   char unit;
-  int sample_loop;
+  float sample_loop;
   int sample_n;
   float attack;
   float hold;

--- a/server.c
+++ b/server.c
@@ -97,7 +97,7 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   float bandq = argc > (23+poffset) ? argv[23+poffset]->f : 0;
 
   char *unit_name = argc > (24+poffset) ? (char *) argv[24+poffset] : "r";
-  int sample_loop = argc > (25+poffset) ? argv[25+poffset]->i : 0;
+  float sample_loop = argc > (25+poffset) ? argv[25+poffset]->f : 0;
   int sample_n = argc > (26+poffset) ? argv[26+poffset]->i : 0;
 
   float attack = argc > (27+poffset) ? argv[27+poffset]->f : 0;


### PR DESCRIPTION
`loop` was changed to a float for Tidal v0.9, which broke classic Dirt.  I've created a new 0.9-dev branch for Dirt, and this commit fixes things, though Dirt doesn't (yet?) handle fractional
loop in the same way as SuperDirt.

I'm not sure what's going on with the `samples` subfolder change, if somebody could help me fix that I'd be thankful.  I can't seem to get github to ignore it.