### PR TITLE
dirt: fix build for gcc-10 (fno-common)

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -38,6 +38,9 @@ PaStream *stream;
 
 #define HALF_PI 1.5707963267948966f
 
+t_line* delays;
+float line_feedback_delay;
+
 pthread_mutex_t queue_loading_lock;
 pthread_mutex_t queue_waiting_lock;
 pthread_mutex_t mutex_sounds;

--- a/audio.h
+++ b/audio.h
@@ -52,8 +52,8 @@ typedef struct {
   int   point;
 } t_line;
 
-t_line* delays;
-float line_feedback_delay;
+extern t_line* delays;
+extern float line_feedback_delay;
 
 typedef struct t_node {
   int    active;


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: audio.o:/home/slyfox/dev/git/Dirt/audio.h:55: multiple definition of
      `delays'; dirt.o:/home/slyfox/dev/git/Dirt/audio.h:55: first defined here
    ld: audio.o:/home/slyfox/dev/git/Dirt/audio.h:56: multiple definition of
      `line_feedback_delay'; dirt.o:/home/slyfox/dev/git/Dirt/audio.h:56: first defined here
    ld: server.o:/home/slyfox/dev/git/Dirt/audio.h:56: multiple definition of
      `line_feedback_delay'; dirt.o:/home/slyfox/dev/git/Dirt/audio.h:56: first defined here
    ld: server.o:/home/slyfox/dev/git/Dirt/audio.h:55: multiple definition of
      `delays'; dirt.o:/home/slyfox/dev/git/Dirt/audio.h:55: first defined here

The change moves globals definitions from .h files to .c files.