### PR TITLE
fix JACK timing (and other minor fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.d
 *.o
 dirt
 dirt-pa

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 CC=gcc
 
 #CFLAGS += -O2 -march=armv6zk -mcpu=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -g -I/usr/local/include -I/opt/local/include -Wall -std=gnu99 -DDEBUG -DHACK -DFASTSIN -Wdouble-promotion
-CFLAGS += -O2 -g -I/usr/local/include -I/opt/local/include -Wall -std=gnu99 -DDEBUG -DHACK -DFASTSIN
+CFLAGS += -O2 -g -I/usr/local/include -I/opt/local/include -Wall -std=gnu99 -DDEBUG -DHACK -DFASTSIN -MMD
+
 LDFLAGS += -g -lm -L/usr/local/lib -L/opt/local/lib -llo -lsndfile -lsamplerate -lpthread 
 
 SOURCES=dirt.c common.c audio.c file.c server.c jobqueue.c thpool.c 
 OBJECTS=$(SOURCES:.c=.o)
+DEPENDS=$(OBJECTS:.o=.d)
 
 dirt: CFLAGS += -DJACK -DSCALEPAN
 dirt: LDFLAGS += -ljack
@@ -36,3 +38,4 @@ install: dirt
 	install -d $(PREFIX)/bin
 	install -m 0755 dirt $(PREFIX)/bin/dirt
 
+-include $(DEPENDS)

--- a/audio.c
+++ b/audio.c
@@ -143,7 +143,7 @@ static void unmark_as_loading(const char* samplename, int success) {
 
 static void reset_sound(t_sound* s);
 
-void read_file_func(void* new) {
+void *read_file_func(void* new) {
   t_sound* sound = new;
   t_sample *sample = file_get(sound->samplename, sampleroot);
   if (sample != NULL) {
@@ -151,6 +151,7 @@ void read_file_func(void* new) {
     init_sound(sound);
   }
   unmark_as_loading(sound->samplename, sample != NULL);
+  return NULL;
 }
 
 int queue_size(t_sound *queue) {
@@ -564,7 +565,7 @@ extern int audio_play(t_sound* sound) {
   else {
     pthread_mutex_lock(&queue_loading_lock);
     if (!is_sample_loading(sound->samplename)) {
-      if (!thpool_add_job(read_file_pool, (void*) read_file_func, (void*) sound)) {
+      if (!thpool_add_job(read_file_pool, read_file_func, (void*) sound)) {
 	fprintf(stderr, "audio_play: Could not add file reading job for '%s'\n", sound->samplename);
       }
     }

--- a/audio.c
+++ b/audio.c
@@ -604,8 +604,7 @@ void init_sound(t_sound *sound) {
   }
 
 #ifdef JACK
-  sound->startT =
-    jack_time_to_frames(jack_client, ((sound->when-epochOffset) * 1000000));
+  sound->startT = (sound->when - epochOffset) * 1000000;
 # else
   sound->startT = sound->when - epochOffset;
 #endif
@@ -1055,9 +1054,10 @@ extern int jack_callback(int frames, float *input, float **outputs) {
   now = jack_last_frame_time(jack_client);
 
   for (int i=0; i < frames; ++i) {
-    playback(outputs, i, now + i);
+    jack_time_t nowt = jack_frames_to_time(jack_client, now + i);
+    playback(outputs, i, nowt);
 
-    dequeue(now + i);
+    dequeue(nowt);
   }
   return(0);
 }

--- a/audio.h
+++ b/audio.h
@@ -16,7 +16,7 @@
 #ifdef JACK
 #include <jack/jack.h>
 #include "jack.h"
-#define sampletime_t jack_nframes_t
+#define sampletime_t jack_time_t
 #else
 #define sampletime_t double
 #endif

--- a/dirt.c
+++ b/dirt.c
@@ -125,8 +125,8 @@ int main (int argc, char **argv) {
 #endif
                "      --late-trigger               enable sample retrigger after loading (default)\n"
                "      --no-late-trigger            disable sample retrigger after loading\n"
-               "      --preload                    enable sample retrigger after loading (default)\n"
-               "      --no-preload                 disable sample retrigger after loading\n"
+               "      --preload                    enable sample preloading at startup\n"
+               "      --no-preload                 disable sample preloading at startup (default)\n"
 	             "  -s  --samples-root-path          set a samples root directory path\n"
                "  -w, --workers                    number of sample-reading workers (default: %u)\n"
                "  -h, --help                       display this help and exit\n"

--- a/file.c
+++ b/file.c
@@ -23,7 +23,7 @@ t_loop *new_loop(float seconds) {
   result->chunksz = 2048;
   result->max_frames = result->frames = seconds * (float) g_samplerate;
   result->items = (float *) calloc(result->frames, sizeof(double));
-  result->in = (double *) calloc(result->chunksz, sizeof(double));
+  result->in = (float *) calloc(result->chunksz, sizeof(double));
   result->now = 0;
   result->loops = 0;
   return(result);

--- a/file.c
+++ b/file.c
@@ -92,9 +92,9 @@ void fix_samplerate (t_sample *sample) {
 extern int file_count_samples(char *set, const char *sampleroot) {
   int result = 0;
   struct dirent **namelist;
-  char path[MAXPATHSIZE];
+  char path[MAXPATHSIZE * 2 + 24];
 
-  snprintf(path, MAXPATHSIZE -1, "%s/%s", sampleroot, set);
+  snprintf(path, sizeof(path), "%s/%s", sampleroot, set);
   result = scandir(path, &namelist, wav_filter, alphasort);
   
   if (result >= 0) {
@@ -122,7 +122,7 @@ extern t_sample *file_get(char *samplename, const char *sampleroot) {
     }
 
     SNDFILE *sndfile;
-    char path[MAXPATHSIZE];
+    char path[2 * MAXPATHSIZE + 24];
     char error[62];
     sf_count_t count;
     float *items;
@@ -135,18 +135,18 @@ extern t_sample *file_get(char *samplename, const char *sampleroot) {
     // load it from disk
     if (sscanf(samplename, "%[a-z0-9A-Z]%[/:]%d", set, sep, &set_n)) {
       int n;
-      snprintf(path, MAXPATHSIZE -1, "%s/%s", sampleroot, set);
+      snprintf(path, sizeof(path), "%s/%s", sampleroot, set);
       //printf("looking in %s\n", set);
       n = scandir(path, &namelist, wav_filter, alphasort);
       if (n > 0) {
-        snprintf(path, MAXPATHSIZE -1,
+        snprintf(path, sizeof(path),
 	    "%s/%s/%s", sampleroot, set, namelist[set_n % n]->d_name);
         while (n--) {
           free(namelist[n]);
         }
         free(namelist);
       } else {
-	snprintf(path, MAXPATHSIZE -1, "%s/%s", sampleroot, samplename);
+	snprintf(path, sizeof(path), "%s/%s", sampleroot, samplename);
       }
     } else {
       snprintf(path, MAXPATHSIZE -1, "%s/%s", sampleroot, samplename);
@@ -211,7 +211,7 @@ extern void file_preload_samples(const char *sampleroot) {
   DIR* srcdir = opendir(sampleroot);
 
   // sample set name
-  char samplename[MAXPATHSIZE];
+  char samplename[MAXPATHSIZE + 24];
   
   if (srcdir == NULL) {
     return;
@@ -229,7 +229,7 @@ extern void file_preload_samples(const char *sampleroot) {
     if (S_ISDIR(st.st_mode)) {
       int n = file_count_samples(dent->d_name, sampleroot);
       for (int i = 0; i < n; ++i) {
-	snprintf(samplename, MAXPATHSIZE -1, "%s:%d", dent->d_name, i);
+	snprintf(samplename, sizeof(samplename), "%s:%d", dent->d_name, i);
 	fprintf(stderr, "> %s\n", samplename);
 	file_get(samplename, sampleroot);
       }

--- a/jack.c
+++ b/jack.c
@@ -51,7 +51,7 @@ extern jack_client_t *jack_start(t_callback callback, bool autoconnect) {
   jack_options_t options = JackNullOption;
   jack_status_t status;
   int i;
-  char portname[16];
+  char portname[24];
 
   /* open a client connection to the JACK server */
   
@@ -98,7 +98,7 @@ extern jack_client_t *jack_start(t_callback callback, bool autoconnect) {
   }
 
   for (i = 0; i < g_num_channels; ++i) {
-    sprintf(portname, "output_%d", i);
+    snprintf(portname, sizeof(portname), "output_%d", i);
     output_ports[i] = jack_port_register(client, portname,
                                          JACK_DEFAULT_AUDIO_TYPE,
                                          JackPortIsOutput, 0);

--- a/jobqueue.c
+++ b/jobqueue.c
@@ -63,7 +63,7 @@ job_t* jobqueue_top(jobqueue_t* q) {
     pthread_mutex_unlock(&q->lock);
 
     return top;
-};
+}
 
 bool jobqueue_pop (jobqueue_t* q, job_t* j) {
     pthread_mutex_lock(&q->lock);

--- a/server.c
+++ b/server.c
@@ -245,7 +245,7 @@ void *zmqthread(void *data){
 
 /**/
 
-extern int server_init(char *osc_port) {
+extern int server_init(const char *osc_port) {
 
   lo_server_thread st = lo_server_thread_new(osc_port, error);
 

--- a/server.c
+++ b/server.c
@@ -107,7 +107,7 @@ int play_handler(const char *path, const char *types, lo_arg **argv,
   int orbit = argc > (30+poffset) ? argv[30+poffset]->i : 0;
   //printf("orb: %d\n", orbit);
   static bool extraWarned = false;
-  if (argc > 30+poffset && !extraWarned) {
+  if (argc > 31+poffset && !extraWarned) {
     printf("play server unexpectedly received extra parameters, maybe update Dirt?\n");
     extraWarned = true;
   }

--- a/server.h
+++ b/server.h
@@ -1,4 +1,4 @@
-extern int server_init(char *osc_port);
+extern int server_init(const char *osc_port);
 extern void osc_send_pitch(double starttime, unsigned int chunk, 
 			   float pitch, float flux, float centroid);
 extern void osc_send_play(double when, int lowchunk, float pitch, float flux, float centroid);

--- a/thpool.c
+++ b/thpool.c
@@ -4,7 +4,7 @@
 
 #include "thpool.h"
 
-static void* thread_do(thpool_t* p);
+static void* thread_do(void* p);
 
 struct thpool {
     pthread_t* threads;
@@ -33,8 +33,8 @@ thpool_t* thpool_init(unsigned int num_threads) {
     p->running = true;
 
     // Initialize and detach threads
-    for (int i = 0; i < num_threads; i++) {
-        int rc = pthread_create(&p->threads[i], NULL, (void*) thread_do, p);
+    for (unsigned int i = 0; i < num_threads; i++) {
+        int rc = pthread_create(&p->threads[i], NULL, thread_do, p);
         if (rc) return NULL;
         pthread_detach(p->threads[i]);
     }
@@ -78,7 +78,8 @@ void thpool_destroy(thpool_t* p) {
 }
 
 
-static void* thread_do(thpool_t* p) {
+static void* thread_do(void *arg) {
+    thpool_t* p = arg;
     job_t j;
 
     while (true) {


### PR DESCRIPTION
The main item is 04955ddae4d4733ff6c9b2a8fc71221a2d1a8146 which fixes degradation with JACK (tested with Pipewire):

The other commits mainly fix minor compilation warnings.
